### PR TITLE
Update link to Verification Requests spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > [!NOTE]
 > This specification has been superceeded. Please see the [Verifiable Presentation Request
-> section of the VCALM specification](https://w3c-ccg.github.io/vcalm/#verifiable-presentation-request).
+> section of the VCALM specification](https://w3c.github.io/vcalm/#requesting-a-presentation).
 
 # Verifiable Presentation Request Specification
 


### PR DESCRIPTION
It moved again. This fixes the README level link (at least).

Just trying to help herd the 🐈's.